### PR TITLE
invert `__has_includes` checks

### DIFF
--- a/ios/AdjustSdk.h
+++ b/ios/AdjustSdk.h
@@ -7,10 +7,10 @@
 //
 
 #import "Adjust.h"
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface AdjustSdk : NSObject <RCTBridgeModule>

--- a/ios/AdjustSdkDelegate.h
+++ b/ios/AdjustSdkDelegate.h
@@ -7,10 +7,10 @@
 //
 
 #import "AdjustSdk.h"
-#if __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
+#if __has_include(<React/RCTBridge.h>)
 #import <React/RCTBridge.h>
+#else
+#import "RCTBridge.h"
 #endif
 
 @interface AdjustSdkDelegate : NSObject<AdjustDelegate>

--- a/ios/AdjustSdkDelegate.m
+++ b/ios/AdjustSdkDelegate.m
@@ -9,10 +9,10 @@
 #import <objc/runtime.h>
 
 #import "AdjustSdkDelegate.h"
-#if __has_include("RCTEventDispatcher.h")
-#import "RCTEventDispatcher.h"
-#else
+#if __has_include(<React/RCTEventDispatcher.h>)
 #import <React/RCTEventDispatcher.h>
+#else
+#import "RCTEventDispatcher.h"
 #endif
 
 @implementation AdjustSdkDelegate


### PR DESCRIPTION
the problem is that `__has_include("RCTBridge.h")` is somehow available to the compiler and it causes duplicate import errors. Due to that the current sdk version doesn’t work with RN 0.40 & 0.41.