### PR TITLE
fix import for RN 0.40+

### DIFF
--- a/ios/AdjustSdk.h
+++ b/ios/AdjustSdk.h
@@ -7,10 +7,10 @@
 //
 
 #import "Adjust.h"
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridgeModule.h>
+#else // back compatibility for RN version < 0.40
+#import "RCTBridgeModule.h"
 #endif
 
 @interface AdjustSdk : NSObject <RCTBridgeModule>

--- a/ios/AdjustSdkDelegate.h
+++ b/ios/AdjustSdkDelegate.h
@@ -7,10 +7,10 @@
 //
 
 #import "AdjustSdk.h"
-#if __has_include("RCTBridge.h")
-#import "RCTBridge.h"
-#else
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTBridge.h>
+#else // back compatibility for RN version < 0.40
+#import "RCTBridge.h"
 #endif
 
 @interface AdjustSdkDelegate : NSObject<AdjustDelegate>

--- a/ios/AdjustSdkDelegate.m
+++ b/ios/AdjustSdkDelegate.m
@@ -9,10 +9,10 @@
 #import <objc/runtime.h>
 
 #import "AdjustSdkDelegate.h"
-#if __has_include("RCTEventDispatcher.h")
-#import "RCTEventDispatcher.h"
-#else
+#if __has_include(<React/RCTAssert.h>)
 #import <React/RCTEventDispatcher.h>
+#else // back compatibility for RN version < 0.40
+#import "RCTEventDispatcher.h"
 #endif
 
 @implementation AdjustSdkDelegate


### PR DESCRIPTION
Hi!

Thanks for your library!
We experienced an issue after updating to 0.40 version of React Native.

`Duplicate interface definition for class 'RCTBridge'`

The reason was the check that `RCTBridgeModule.h` was imported. 
So I checked how it is implemented in CodePush and other libraries and changed the implementation to work analogically. 

Currently it works well with RN 0.40+ app