### PR TITLE
Adds react to podspec so that 'use_frameworks!' Podfiles will work

### DIFF
--- a/react-native-adjust.podspec
+++ b/react-native-adjust.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'Adjust', '~> 4.11.4'
+  s.dependency 'React'
 end


### PR DESCRIPTION
If an app using `use_frameworks!` in their `Podfile` tries to use `react-native-adjust.podspec`, compilation will fail. The failure message will be something about how `<React/*.h>` does not exist where `*` can be `RCTLog` or `RCTEventEmitter` depending on which file failed compilation first.

I've merged this solution before here: https://github.com/Appboy/appboy-react-sdk/pull/23
I took the original solution from here: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/1618