### PR TITLE
Add TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,59 @@
+declare module "react-native-adjust" {
+    type Environment = "sandbox" | "production";
+  
+    enum LogLevel {
+      Verbose,
+      Debug,
+      Info,
+      Warn,
+      Error,
+      Assert,
+      Suppress
+    }
+  
+    export class AdjustConfig {
+      constructor(appToken: string, environment: Environment) {}
+  
+      public setLogLevel(level: LogLevel): void {}
+  
+      static get LogLevelVerbose(): LogLevel {
+        return LogLevel.Verbose;
+      }
+  
+      static get LogLevelDebug(): LogLevel {
+        return LogLevel.Debug;
+      }
+  
+      static get LogLevelInfo(): LogLevel {
+        return LogLevel.Info;
+      }
+  
+      static get LogLevelWarn(): LogLevel {
+        return LogLevel.Warn;
+      }
+  
+      static get LogLevelError(): LogLevel {
+        return LogLevel.Error;
+      }
+  
+      static get LogLevelAssert(): LogLevel {
+        return LogLevel.Assert;
+      }
+  
+      static get LogLevelSuppress(): LogLevel {
+        return LogLevel.Suppress;
+      }
+  
+      static get EnvironmentSandbox(): Environment {
+        return "sandbox";
+      }
+      static get EnvironmentProduction(): Environment {
+        return "production";
+      }
+    }
+  
+    export const Adjust = {
+      create: (adjustConfig: any): void => {},
+      componentWillUnmount: (): void => {}
+    };
+  }


### PR DESCRIPTION
According to the instruction [here](https://www.triplet.fi/blog/three-ways-to-provide-typescript-type-definitions-to-3rd-party-libraries/), all we need to do is add a index.d.ts file adjacent to index.js. There is no need to modify package.json AFAIK.

These are the types I am currently using in my project. They don't define the entire SDK, but it is a start.