### PR TITLE
Minor docs update - use componentDidMount

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ import { Adjust, AdjustEvent, AdjustConfig } from 'react-native-adjust';
 In your `index.android.js` or `index.ios.js` file, add the following code to initialize the Adjust SDK:
 
 ```javascript
-componentWillMount() {
+componentDidMount() {
     var adjustConfig = new AdjustConfig("{YourAppToken}", AdjustConfig.EnvironmentSandbox);
     Adjust.create(adjustConfig);
 }

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ In your `index.android.js` or `index.ios.js` file, add the following code to ini
 
 ```javascript
 componentDidMount() {
-    var adjustConfig = new AdjustConfig("{YourAppToken}", AdjustConfig.EnvironmentSandbox);
+    const adjustConfig = new AdjustConfig("{YourAppToken}", AdjustConfig.EnvironmentSandbox);
     Adjust.create(adjustConfig);
 }
 


### PR DESCRIPTION
Would suggest to use `componentDidMount` here, since `componentWillMount` will be deprecated:
https://reactjs.org/docs/react-component.html#unsafe_componentwillmount