### PR TITLE
Sync README and Example app with ReactJS updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@ You should use the following import statement on top of your `.js` file
 import { Adjust, AdjustEvent, AdjustConfig } from 'react-native-adjust';
 ```
 
-In your `index.android.js` or `index.ios.js` file, add the following code to initialize the Adjust SDK:
+In your `App.js` file, add the following code to initialize the Adjust SDK:
 
 ```javascript
-componentWillMount() {
-    var adjustConfig = new AdjustConfig("{YourAppToken}", AdjustConfig.EnvironmentSandbox);
+constructor(props) {
+    super(props);
+    const adjustConfig = new AdjustConfig("{YourAppToken}", AdjustConfig.EnvironmentSandbox);
     Adjust.create(adjustConfig);
 }
 

--- a/example/App.js
+++ b/example/App.js
@@ -4,16 +4,9 @@
 
   type Props = {};
   export default class App extends Component<Props> {
-    componentDidMount() {
-      Linking.addEventListener('url', this.handleDeepLink);
-      Linking.getInitialURL().then((url) => {
-        if (url) {
-          this.handleDeepLink({ url });
-        }
-      })
-    }
+    constructor(props) {
+      super(props);
 
-    componentWillMount() {
       this._onPress_trackSimpleEvent   = this._onPress_trackSimpleEvent.bind(this);
       this._onPress_trackRevenueEvent  = this._onPress_trackRevenueEvent.bind(this);
       this._onPress_trackCallbackEvent = this._onPress_trackCallbackEvent.bind(this);
@@ -29,7 +22,7 @@
         console.log("Adjust SDK version: " + sdkVersion);
       });
 
-      var adjustConfig = new AdjustConfig("2fm9gkqubvpc", AdjustConfig.EnvironmentSandbox);
+      const adjustConfig = new AdjustConfig("2fm9gkqubvpc", AdjustConfig.EnvironmentSandbox);
       adjustConfig.setLogLevel(AdjustConfig.LogLevelVerbose);
       adjustConfig.setShouldLaunchDeeplink(true);
       adjustConfig.setSendInBackground(true);
@@ -114,6 +107,15 @@
       Adjust.create(adjustConfig);
 
       // Adjust.sendFirstPackages();
+    }
+
+    componentDidMount() {
+      Linking.addEventListener('url', this.handleDeepLink);
+      Linking.getInitialURL().then((url) => {
+        if (url) {
+          this.handleDeepLink({ url });
+        }
+      })
     }
 
     componentWillUnmount() {

--- a/test/app/App.js
+++ b/test/app/App.js
@@ -40,7 +40,9 @@
 
     type Props = {};
     export default class App extends Component<Props> {
-        componentWillMount() {
+        constructor(props) {
+            super(props);
+            
             var baseUrl = "";
             var gdprUrl = "";
             if (Platform.OS === "android") {


### PR DESCRIPTION
This small update changes the example app and README in accordance with the new ReactJS deprecation (and soon removal) of `componentWillMount()` lifecycle method.