### PR TITLE
Update .gitmodules URLs to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "ext/android/sdk"]
 	path = ext/android/sdk
-	url = git@github.com:adjust/android_sdk.git
+	url = https://github.com/adjust/android_sdk.git
 	branch = master
 [submodule "ext/ios/sdk"]
 	path = ext/ios/sdk
-	url = git@github.com:adjust/ios_sdk.git
+	url = https://github.com/adjust/ios_sdk.git
 	branch = master


### PR DESCRIPTION
I ran into the following issue when deploying to Heroku with this package in the `package.json`:

```
-----> Installing dependencies
       Installing node modules (package.json + package-lock)
       Unhandled rejection Error: Command failed: /usr/bin/git submodule update -q --init --recursive
       warning: templates not found /tmp/pacote-git-template-tmp/git-clone-1f26257e
       Host key verification failed.
       fatal: Could not read from remote repository.
       
       Please make sure you have the correct access rights
       and the repository exists.
       fatal: clone of 'git@github.com:adjust/android_sdk.git' into submodule path 'ext/android/sdk' failed
```

[This article](https://salferrarello.com/git-submodule-fatal-read-remote-repository/) explains why you should always declare git submodule URLs as HTTPS rather than the `git@github.com:` SSH form for maximum compatibility. This PR makes that simple change, fixing the issue.