### PR TITLE
README.md - clarification regarding requestTrackingAuthorizationWithC…

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ Adjust.requestTrackingAuthorizationWithCompletionHandler(function(status) {
 });
 ```
 
+Before calling the method, ensure that your app's Info.plist contains an entry for 'NSUserTrackingUsageDescription' explaining your tracking usage, as the app will crash otherwise.
+
 ### <a id="skadn-framework"></a>SKAdNetwork framework
 
 **Note**: This feature exists only in iOS platform.


### PR DESCRIPTION
…ompletionHandler

Without the 'NSUserTrackingUsageDescription' my app crashed upon calling the method.

Message recorded before crash:
   2020-10-08 12:04:01.498768+0200 BirdsAreAwesomeApp[2808:1455098] [access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSUserTrackingUsageDescription key with a string value explaining to the user how the app uses this data.

---

Feel free to rephrase or solve in some other manner, I just felt like the information would be useful to have. :)