### PR TITLE
fix(android): return type getAppTrackingAuthorizationStatus

### DIFF
--- a/android/src/main/java/com/adjust/sdk/Adjust.java
+++ b/android/src/main/java/com/adjust/sdk/Adjust.java
@@ -714,7 +714,7 @@ public class Adjust extends ReactContextBaseJavaModule implements LifecycleEvent
 
     @ReactMethod
     public void getAppTrackingAuthorizationStatus(Callback callback) {
-        callback.invoke("-1");
+        callback.invoke(-1);
     }
 
     @ReactMethod


### PR DESCRIPTION
on iOS it is an int, makes no sense to be different here