### PR TITLE
Fix Autoinstall for react-native 0.69

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   dependency: {
     platforms: {
-      ios: { podspecPath: path.join(__dirname, 'react-native-adjust.podspec') },
+      ios: {},
       android: {
         packageImportPath: 'import com.adjust.nativemodule.AdjustPackage;',
         packageInstance: 'new AdjustPackage()',


### PR DESCRIPTION
Fixes #185 

Removed deprecated params from 'react-native.config.js' that was preventing autolinking to be applied

audolinking automatically assumes that podspec file is in the root of package directory, so specifying podspecPath in the config is no longer necessary

Source: https://github.com/react-native-community/cli/blob/master/docs/autolinking.md

> On the iOS side, you will need to ensure you have a Podspec to the root of your repo. The react-native-webview Podspec is a good example of a [package.json](https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec)-driven Podspec. Note that CocoaPods does not support having /s in the name of a dependency, so if you are using scoped packages - you may need to change the name for the Podspec.